### PR TITLE
Only show warnings for the shippo module itself

### DIFF
--- a/shippo/resource.py
+++ b/shippo/resource.py
@@ -5,7 +5,7 @@ import warnings
 
 from shippo import api_requestor, error, util, rates_req_timeout
 
-warnings.simplefilter('always', DeprecationWarning)
+warnings.filterwarnings('always', category=DeprecationWarning, module='shippo')
 
 
 def convert_to_shippo_object(resp, api_key):


### PR DESCRIPTION
Currently the act of `import shippo` results in turning on deprecation
warnings for everything.  This results in warnings in other modules,
like ipython for example:

    $ virtualenv newenv
    $ newenv/bin/pip install shippo ipython
    $ newenv/bin/python
    >>> import shippo
    >>> from IPython import start_ipython
    /tmp/newenv/lib/python2.7/site-packages/IPython/utils/io.py:86: DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
      stdin = IOStream(sys.stdin, fallback=devnull)
    /tmp/newenv/lib/python2.7/site-packages/IPython/utils/io.py:87: DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
      stdout = IOStream(sys.stdout, fallback=devnull)
    /tmp/newenv/lib/python2.7/site-packages/IPython/utils/io.py:88: DeprecationWarning: IOStream is deprecated since IPython 5.0, use sys.{stdin,stdout,stderr} instead
      stderr = IOStream(sys.stderr, fallback=devnull)
    /tmp/newenv/lib/python2.7/site-packages/IPython/core/shellapp.py:27: DeprecationWarning: `IPython.lib.inputhook` is deprecated since IPython 5.0 and will be removed in future versions.
      from IPython.lib.inputhook import guis
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:327: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('osx')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:336: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('wx')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:398: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('qt', 'qt4')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:449: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('qt5')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:458: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('gtk')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:489: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('tk')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:522: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('glut')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:596: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('pyglet')
    /tmp/newenv/lib/python2.7/site-packages/IPython/lib/inputhook.py:624: DeprecationWarning: `register` is deprecated since IPython 5.0 and will be removed in future versions.
      @inputhook_manager.register('gtk3')

This is especially annoying while doing Django development since
`python manage.py shell` imports and uses IPython in this way,
resulting in this wall of DeprecationWarnings every time you start the
shell (if you're using shippo in your project).

Avoid this behavior by only warning for the shippo module itself.