### PR TITLE
Support for python 3.6+: deprecates the 'async' keyword argument (now…

### DIFF
--- a/examples/basic-shipment.py
+++ b/examples/basic-shipment.py
@@ -48,13 +48,13 @@ parcel = {
 
 # Example shipment object
 # For complete reference to the shipment object: https://goshippo.com/docs/reference#shipments
-# This object has async=False, indicating that the function will wait until all rates are generated before it returns.
+# This object has asynchronous=False, indicating that the function will wait until all rates are generated before it returns.
 # By default, Shippo handles responses asynchronously. However this will be depreciated soon. Learn more: https://goshippo.com/docs/async
 shipment = shippo.Shipment.create(
     address_from=address_from,
     address_to=address_to,
     parcels=[parcel],
-    async=False
+    asynchronous=False
 )
 
 # Rates are stored in the `rates` array
@@ -62,10 +62,10 @@ shipment = shippo.Shipment.create(
 # Get the first rate in the rates results for demo purposes.
 rate = shipment.rates[0]
 # Purchase the desired rate with a transaction request
-# Set async=False, indicating that the function will wait until the carrier returns a shipping label before it returns
-transaction = shippo.Transaction.create(rate=rate.object_id, async=False)
+# Set asynchronous=False, indicating that the function will wait until the carrier returns a shipping label before it returns
+transaction = shippo.Transaction.create(rate=rate.object_id, asynchronous=False)
 
-# print the shipping label from label_url 
+# print the shipping label from label_url
 # Get the tracking number from tracking_number
 if transaction.status == "SUCCESS":
     print "Purchased label with tracking number %s" % transaction.tracking_number
@@ -74,6 +74,6 @@ else:
     print "Failed purchasing the label due to:"
     for message in transaction.messages:
         print "- %s" % message['text']
-        
+
 #For more tutorals of address validation, tracking, returns, refunds, and other functionality, check out our
 #complete documentation: https://goshippo.com/docs/

--- a/examples/batch.py
+++ b/examples/batch.py
@@ -48,7 +48,7 @@ example_batch = {
           }
         },
         {
-          "shipment": {    
+          "shipment": {
             "address_from": {
               "name": "Mr Hippo",
               "street1": "1092 Indian Summer Ct",
@@ -136,7 +136,7 @@ shipment = shippo.Shipment.create(
     address_from=address_from,
     address_to=address_to,
     parcels=[parcel],
-    async=False
+    asynchronous=False
 )
 
 #the post data should be in an array even if it's just one shipment
@@ -157,6 +157,6 @@ removed = shippo.Batch.remove(batch.object_id, to_remove)
 #now we're ready to purchase
 purchase = shippo.Batch.purchase(batch.object_id)
 print purchase
-        
+
 #For more tutorals of address validation, tracking, returns, refunds, and other functionality, check out our
 #complete documentation: https://goshippo.com/docs/

--- a/examples/estimate-shipping-prices.py
+++ b/examples/estimate-shipping-prices.py
@@ -1,7 +1,7 @@
 import shippo
 
 """
-In this tutorial we want to calculate our average shipping costs so 
+In this tutorial we want to calculate our average shipping costs so
 we set pricing for customers.
 
 We have a sender address, a parcel and a set of delivery zip codes.
@@ -53,7 +53,7 @@ address_to = {
     "country": "US"
 }
 
-# Sample parcel, make sure to replace placeholders with your average shipment size 
+# Sample parcel, make sure to replace placeholders with your average shipment size
 # The complete reference for parcel object is here: https://goshippo.com/docs/reference#parcels
 
 parcel = {
@@ -74,20 +74,20 @@ shipping_costs = {}
 for delivery_address_zip_code in DESTINATION_ADDRESSES_ZIP_CODES:
     # Change delivery address to current delivery address
     address_to['zip'] = delivery_address_zip_code
-    # Creating the shipment object. async=False indicates that the function will wait until all
+    # Creating the shipment object. asynchronous=False indicates that the function will wait until all
     # rates are generated before it returns.
     # The reference for the shipment object is here: https://goshippo.com/docs/reference#shipments
     # By default Shippo API operates on an async basis. You can read about our async flow here: https://goshippo.com/docs/async
-    
+
     shipment = shippo.Shipment.create(
         address_from=address_from,
         address_to=address_to,
         parcels=[parcel],
-        async=False
+        asynchronous=False
     )
     # Rates are stored in the `rates` array
     # The details on the returned object are here: https://goshippo.com/docs/reference#rates
-    
+
     rates = shipment.rates
     print "Returned %s rates to %s" % (len(rates), delivery_address_zip_code)
     # We now store the shipping cost for each delivery window in our
@@ -113,6 +113,6 @@ for delivery_window in DELIVERY_WINDOWS:
         print "--> Max. costs: %0.2f" % max(costs)
         print "--> Avg. costs: %0.2f" % (sum(costs) / float(len(costs)))
         print "\n"
-        
+
 # For more tutorals of address validation, tracking, returns, refunds, and other functionality, check out our
 # complete documentation: https://goshippo.com/docs/

--- a/examples/filter-by-delivery-time.py
+++ b/examples/filter-by-delivery-time.py
@@ -51,7 +51,7 @@ parcel = {
     "mass_unit": "lb",
 }
 
-# Creating the shipment object. async=False indicates that the function will wait until all
+# Creating the shipment object. asynchronous=False indicates that the function will wait until all
 # rates are generated before it returns.
 # The reference for the shipment object is here: https://goshippo.com/docs/reference#shipments
 # By default Shippo API operates on an async basis. You can read about our async flow here: https://goshippo.com/docs/async
@@ -59,7 +59,7 @@ shipment = shippo.Shipment.create(
     address_from=address_from,
     address_to=address_to,
     parcels=[parcel],
-    async=False
+    asynchronous=False
 )
 
 # Rates are stored in the `rates` array
@@ -72,9 +72,9 @@ rate = min(eligible_rate, key=lambda x: float(x['amount']))
 print "Picked service %s %s for %s %s with est. transit time of %s days" % \
     (rate['provider'], rate['servicelevel']['name'], rate['currency'], rate['amount'], rate['days'])
 
-# Purchase the desired rate. async=False indicates that the function will wait until the
+# Purchase the desired rate. asynchronous=False indicates that the function will wait until the
 # carrier returns a shipping label before it returns
-transaction = shippo.Transaction.create(rate=rate.object_id, async=False)
+transaction = shippo.Transaction.create(rate=rate.object_id, asynchronous=False)
 
 # print label_url and tracking_number
 if transaction.status == "SUCCESS":
@@ -84,6 +84,6 @@ else:
     print "Failed purchasing the label due to:"
     for message in transaction.messages:
         print "- %s" % message['text']
-        
+
 #For more tutorals of address validation, tracking, returns, refunds, and other functionality, check out our
 #complete documentation: https://goshippo.com/docs/

--- a/examples/get-rates-to-show-customer.py
+++ b/examples/get-rates-to-show-customer.py
@@ -52,13 +52,13 @@ parcel = {
 
 # Example shipment object
 # For complete reference to the shipment object: https://goshippo.com/docs/reference#shipments
-# This object has async=False, indicating that the function will wait until all rates are generated before it returns.
+# This object has asynchronous=False, indicating that the function will wait until all rates are generated before it returns.
 # By default, Shippo handles responses asynchronously. However this will be depreciated soon. Learn more: https://goshippo.com/docs/async
 shipment = shippo.Shipment.create(
     address_from=address_from,
     address_to=address_to,
     parcels=[parcel],
-    async=False
+    asynchronous=False
 )
 
 # Rates are stored in the `rates` array
@@ -66,24 +66,24 @@ shipment = shippo.Shipment.create(
 rates = shipment.rates
 
 """
-You can now show those rates to the user in your UI. 
+You can now show those rates to the user in your UI.
 Most likely you want to show some of the following fields:
 - provider (carrier name)
 - servicelevel_name
 - amount (price of label - you could add e.g. a 10% markup here)
 - days (transit time)
-Don't forget to store the `object_id` of each Rate so that you 
+Don't forget to store the `object_id` of each Rate so that you
 can use it for the label purchase later.
 """
 
 # After the user has selected a rate, use the corresponding object_id
 selected_rate_object_id = '<SELECTED-RATE-OBJECT-ID>'
 
-# Purchase the desired rate. async=False indicates that the function will wait until the
+# Purchase the desired rate. asynchronous=False indicates that the function will wait until the
 # carrier returns a shipping label before it returns
-transaction = shippo.Transaction.create(rate=selected_rate_object_id, async=False)
+transaction = shippo.Transaction.create(rate=selected_rate_object_id, asynchronous=False)
 
-# print the shipping label from label_url 
+# print the shipping label from label_url
 # Get the tracking number from tracking_number
 if transaction.status == "SUCCESS":
     print "Purchased label with tracking number %s" % transaction.tracking_number
@@ -92,6 +92,6 @@ else:
     print "Failed purchasing the label due to:"
     for message in transaction.messages:
         print "- %s" % message['text']
-        
+
 #For more tutorals of address validation, tracking, returns, refunds, and other functionality, check out our
-#complete documentation: https://goshippo.com/docs/        
+#complete documentation: https://goshippo.com/docs/

--- a/examples/international-shipment.py
+++ b/examples/international-shipment.py
@@ -2,7 +2,7 @@ import shippo
 
 """
 In this tutorial we have an order with a sender address,
-recipient address and parcel. The shipment is going from the 
+recipient address and parcel. The shipment is going from the
 United States to an international location.
 
 In addition to that we know that the customer expects the
@@ -79,7 +79,7 @@ customs_declaration = shippo.CustomsDeclaration.create(
     certify_signer= 'Mr Hippo',
     items= [customs_item])
 
-# Creating the shipment object. async=False indicates that the function will wait until all
+# Creating the shipment object. asynchronous=False indicates that the function will wait until all
 # rates are generated before it returns.
 
 # The reference for the shipment object is here: https://goshippo.com/docs/reference#shipments
@@ -89,7 +89,7 @@ shipment_international = shippo.Shipment.create(
     address_to= address_to_international,
     parcels= [parcel],
     customs_declaration=customs_declaration.object_id,
-    async= False )
+    asynchronous= False )
 
 # Get the first rate in the rates results for demo purposes.
 # The details on the returned object are here: https://goshippo.com/docs/reference#rates
@@ -97,7 +97,7 @@ rate_international = shipment_international.rates[0]
 
 # Purchase the desired rate.
 # The complete information about purchasing the label: https://goshippo.com/docs/reference#transaction-create
-transaction_international = shippo.Transaction.create(rate=rate_international.object_id, async=False)
+transaction_international = shippo.Transaction.create(rate=rate_international.object_id, asynchronous=False)
 
 # print label_url and tracking_number
 if transaction_international.status == "SUCCESS":

--- a/examples/purchase-fastest-service.py
+++ b/examples/purchase-fastest-service.py
@@ -4,7 +4,7 @@ import shippo
 In this tutorial we have an order with a sender address,
 recipient address and parcel information that we need to ship.
 
-We want to get the cheapest shipping label that will 
+We want to get the cheapest shipping label that will
 get the packages to the customer within 3 days.
 """
 
@@ -52,7 +52,7 @@ parcel = {
     "mass_unit": "lb",
 }
 
-# Creating the shipment object. async=False indicates that the function will wait until all
+# Creating the shipment object. asynchronous=False indicates that the function will wait until all
 # rates are generated before it returns.
 # The reference for the shipment object is here: https://goshippo.com/docs/reference#shipments
 # By default Shippo API operates on an async basis. You can read about our async flow here: https://goshippo.com/docs/async
@@ -60,7 +60,7 @@ shipment = shippo.Shipment.create(
     address_from=address_from,
     address_to=address_to,
     parcels=[parcel],
-    async=False
+    asynchronous=False
 )
 
 # Rates are stored in the `rates` array
@@ -73,9 +73,9 @@ rate = min(eligible_rates, key=lambda x: float(x['amount']))
 print "Picked service %s %s for %s %s with est. transit time of %s days" % \
     (rate['provider'], rate['servicelevel']['name'], rate['currency'], rate['amount'], rate['days'])
 
-# Purchase the desired rate. async=False indicates that the function will wait until the
+# Purchase the desired rate. asynchronous=False indicates that the function will wait until the
 # carrier returns a shipping label before it returns
-transaction = shippo.Transaction.create(rate=rate.object_id, async=False)
+transaction = shippo.Transaction.create(rate=rate.object_id, asynchronous=False)
 
 # print label_url and tracking_number
 if transaction.status == "SUCCESS":

--- a/shippo/test/helper.py
+++ b/shippo/test/helper.py
@@ -203,7 +203,7 @@ DUMMY_BATCH = {
     "metadata": "BATCH #170",
     "batch_shipments": [
         {
-          "shipment": {    
+          "shipment": {
             "address_from": {
               "name": "Mr Hippo",
               "street1": "965 Mission St",
@@ -236,7 +236,7 @@ DUMMY_BATCH = {
           }
         },
         {
-          "shipment": {    
+          "shipment": {
             "address_from": {
               "name": "Mr Hippo",
               "street1": "1092 Indian Summer Ct",
@@ -278,7 +278,7 @@ INVALID_BATCH = {
 }
 
 
-def create_mock_shipment(async=False, api_key=None):
+def create_mock_shipment(asynchronous=False, api_key=None):
     to_address = shippo.Address.create(api_key=api_key, **TO_ADDRESS)
     from_address = shippo.Address.create(api_key=api_key, **FROM_ADDRESS)
     parcel = shippo.Parcel.create(api_key=api_key, **DUMMY_PARCEL)
@@ -286,7 +286,7 @@ def create_mock_shipment(async=False, api_key=None):
     SHIPMENT['address_from'] = from_address.object_id
     SHIPMENT['address_to'] = to_address.object_id
     SHIPMENT['parcels'] = [parcel.object_id]
-    SHIPMENT['async'] = async
+    SHIPMENT['asynchronous'] = asynchronous
     shipment = shippo.Shipment.create(api_key=api_key, **SHIPMENT)
     return shipment
 
@@ -303,13 +303,13 @@ def create_mock_manifest(transaction=None):
     return manifest
 
 
-def create_mock_transaction(async=False):
-    shipment = create_mock_shipment(async)
+def create_mock_transaction(asynchronous=False):
+    shipment = create_mock_shipment(asynchronous)
     rates = shipment.rates
     usps_rate = list(filter(lambda x: x.servicelevel.token == 'usps_priority', rates))[0]
     t = DUMMY_TRANSACTION.copy()
     t['rate'] = usps_rate.object_id
-    t['async'] = async
+    t['asynchronous'] = asynchronous
     txn = shippo.Transaction.create(**t)
     return txn
 

--- a/shippo/test/integration/test_integration.py
+++ b/shippo/test/integration/test_integration.py
@@ -71,7 +71,7 @@ class FunctionalTests(ShippoTestCase):
     def test_get_rates(self):
         try:
             shipment = create_mock_shipment()
-            rates = shippo.Shipment.get_rates(shipment.object_id, async=False)
+            rates = shippo.Shipment.get_rates(shipment.object_id, asynchronous=False)
         except shippo.error.InvalidRequestError:
             pass
         except shippo.error.AuthenticationError:

--- a/shippo/test/test_rate.py
+++ b/shippo/test/test_rate.py
@@ -35,7 +35,7 @@ class RateTests(ShippoTestCase):
     @shippo_vcr.use_cassette(cassette_library_dir='shippo/test/fixtures/rate')
     def test_retrieve(self):
         shipment = create_mock_shipment()
-        rates = shippo.Shipment.get_rates(shipment.object_id, async=False)
+        rates = shippo.Shipment.get_rates(shipment.object_id, asynchronous=False)
         rate = rates.results[0]
         retrieve = shippo.Rate.retrieve(rate.object_id)
         self.assertItemsEqual(rate, retrieve)

--- a/shippo/test/test_shipment.py
+++ b/shippo/test/test_shipment.py
@@ -74,14 +74,14 @@ class ShipmentTests(ShippoTestCase):
     @shippo_vcr.use_cassette(cassette_library_dir='shippo/test/fixtures/shipment')
     def test_get_rates_blocking(self):
         shipment = create_mock_shipment()
-        rates = shippo.Shipment.get_rates(shipment.object_id, async=False)
+        rates = shippo.Shipment.get_rates(shipment.object_id, asynchronous=False)
         self.assertTrue('results' in rates)
 
     @shippo_vcr.use_cassette(cassette_library_dir='shippo/test/fixtures/shipment')
     def test_invalid_get_rate(self):
-        # we are testing async=True in order to test the 2nd API call of the function
+        # we are testing asynchronous=True in order to test the 2nd API call of the function
         self.assertRaises(shippo.error.APIError, shippo.Shipment.get_rates,
-                          'EXAMPLE_OF_INVALID_ID', async=True)
+                          'EXAMPLE_OF_INVALID_ID', asynchronous=True)
 
 
 if __name__ == '__main__':

--- a/shippo/test/test_transaction.py
+++ b/shippo/test/test_transaction.py
@@ -39,7 +39,7 @@ class TransactionTests(ShippoTestCase):
     @shippo_vcr.use_cassette(cassette_library_dir='shippo/test/fixtures/transaction')
     def test_create(self):
         shipment = create_mock_shipment()
-        rates = shippo.Shipment.get_rates(shipment.object_id, async=False)
+        rates = shippo.Shipment.get_rates(shipment.object_id, asynchronous=False)
         rate = rates.results[0]
         TRANSACTION = DUMMY_TRANSACTION.copy()
         TRANSACTION['rate'] = rate.object_id
@@ -49,7 +49,7 @@ class TransactionTests(ShippoTestCase):
     @shippo_vcr.use_cassette(cassette_library_dir='shippo/test/fixtures/transaction')
     def test_retrieve(self):
         shipment = create_mock_shipment()
-        rates = shippo.Shipment.get_rates(shipment.object_id, async=False)
+        rates = shippo.Shipment.get_rates(shipment.object_id, asynchronous=False)
         rate = rates.results[0]
         TRANSACTION = DUMMY_TRANSACTION.copy()
         TRANSACTION['rate'] = rate.object_id

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, pypy3.3-5.2-alpha1, py33, py34, py35
+envlist = py26, py27, pypy, pypy3.3-5.2-alpha1, py33, py34, py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Support for python 3.6+: deprecates the 'async' keyword argument (now a SyntaxError), in favor of 'asynchronous'. Updates docs, examples, tests.