### PR TITLE
Replace "asynchronous" with "async" in the API request params

### DIFF
--- a/shippo/api_requestor.py
+++ b/shippo/api_requestor.py
@@ -109,6 +109,9 @@ class APIRequestor(object):
 
         abs_url = '%s%s' % (shippo.api_base, url)
 
+        if 'asynchronous' in params:
+            params['async'] = params['asynchronous']
+        
         if method == 'get' or method == 'delete':
             if params:
                 encoded_params = urllib.parse.urlencode(list(_api_encode(params or {})))


### PR DESCRIPTION
The API still expects `async` as the parameter and not `asynchronous`. This renames the param before making the request (in a bit of hacky way).