### PR TITLE
Update setup.py install_requires to use compatible package versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     packages=['shippo', 'shippo.test', 'shippo.test.integration'],
     package_data={'shippo': ['../VERSION']},
     install_requires=[
-        'requests == 2.21.0',
-        'simplejson == 3.16.0',
+        'requests ~= 2.21',
+        'simplejson ~= 3.16',
     ],
     test_suite='shippo.test.all',
     tests_require=['unittest2', 'mock', 'vcrpy'],


### PR DESCRIPTION
Use [compatible release](https://www.python.org/dev/peps/pep-0440/#compatible-release) versions for  `install_dependencies` instead of fixed versions.

This allows integration with projects that "pin" different versions of required dependencies.