### PR TITLE
Bump requests >= 2.21.0, <= 2.24.0 and simple_json >= 3.16.0, <= 3.17.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     packages=['shippo', 'shippo.test', 'shippo.test.integration'],
     package_data={'shippo': ['../VERSION']},
     install_requires=[
-        'requests == 2.21.0',
-        'simplejson == 3.16.0',
+        'requests >= 2.21.0, <= 2.24.0',
+        'simplejson >= 3.16.0, <= 3.17.2',
     ],
     test_suite='shippo.test.all',
     tests_require=['unittest2', 'mock', 'vcrpy'],


### PR DESCRIPTION
- Increase range for `requests` and `simple_json` libraries, as right now it supports just one version of each and this tends to cause incompatibilities with other libraries.

Testing this with different `requests` and `simple_json` versions was satisfactory.

Fixes #64 