### PR TITLE
Increase requests requirement range to cover version 2.27.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['shippo', 'shippo.test', 'shippo.test.integration'],
     package_data={'shippo': ['../VERSION']},
     install_requires=[
-        'requests >= 2.21.0, <= 2.26.0',
+        'requests >= 2.21.0, <= 2.27.1',
         'simplejson >= 3.16.0, <= 3.17.2',
     ],
     test_suite='shippo.test.all',


### PR DESCRIPTION
New version of requests released

<img width="830" alt="Screenshot 2022-02-25 at 19 51 09" src="https://user-images.githubusercontent.com/22962693/155771310-5270c82e-1bc3-4103-a374-3bd206081686.png">

Not having it causes inconsistencies and problems with dependabot and poetry

Related to #70