### PR TITLE
Update v1 url

### DIFF
--- a/shippo/resource.py
+++ b/shippo/resource.py
@@ -165,7 +165,7 @@ class APIResource(ShippoObject):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "/v1/%ss" % (cls_name,)
+        return "%ss" % (cls_name,)
 
     def instance_url(self):
         object_id = self.get('object_id')
@@ -256,21 +256,21 @@ class Address(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ses/" % (cls_name,)
+        return "%ses/" % (cls_name,)
 
 
 class CustomsItem(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
 
     @classmethod
     def class_url(cls):
-        return "v1/customs/items/"
+        return "customs/items/"
 
 
 class CustomsDeclaration(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
 
     @classmethod
     def class_url(cls):
-        return "v1/customs/declarations/"
+        return "customs/declarations/"
 
 
 class Order(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
@@ -281,7 +281,7 @@ class Order(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Parcel(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
@@ -289,7 +289,7 @@ class Parcel(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Pickup(CreateableAPIResource):
@@ -312,7 +312,7 @@ class Manifest(CreateableAPIResource, ListableAPIResource, FetchableAPIResource)
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Refund(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
@@ -323,7 +323,7 @@ class Refund(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Shipment(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
@@ -353,7 +353,7 @@ class Shipment(CreateableAPIResource, ListableAPIResource, FetchableAPIResource)
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Transaction(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):
@@ -374,7 +374,7 @@ class Transaction(CreateableAPIResource, ListableAPIResource, FetchableAPIResour
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Rate(ListableAPIResource, FetchableAPIResource):
@@ -386,14 +386,14 @@ class Rate(ListableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class CarrierAccount(CreateableAPIResource, ListableAPIResource, FetchableAPIResource, UpdateableAPIResource):
 
     @classmethod
     def class_url(cls):
-        return "v1/carrier_accounts/"
+        return "carrier_accounts/"
 
 
 class Webhook(CreateableAPIResource, ListableAPIResource, FetchableAPIResource, UpdateableAPIResource):
@@ -406,7 +406,7 @@ class Webhook(CreateableAPIResource, ListableAPIResource, FetchableAPIResource, 
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
     @classmethod
     def list_webhooks(cls, api_key=None, **params):
@@ -515,7 +515,7 @@ class Track(CreateableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ss/" % (cls_name,)
+        return "%ss/" % (cls_name,)
 
 
 class Batch(CreateableAPIResource, FetchableAPIResource):
@@ -629,7 +629,7 @@ class Batch(CreateableAPIResource, FetchableAPIResource):
     @classmethod
     def class_url(cls):
         cls_name = cls.class_name()
-        return "v1/%ses/" % (cls_name,)
+        return "%ses/" % (cls_name,)
 
 
 class Order(CreateableAPIResource, ListableAPIResource, FetchableAPIResource):

--- a/shippo/test/fixtures/address/test_create
+++ b/shippo/test/fixtures/address/test_create
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_invalid_create
+++ b/shippo/test/fixtures/address/test_invalid_create
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_invalid_retrieve
+++ b/shippo/test/fixtures/address/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/addresses/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_invalid_validate
+++ b/shippo/test/fixtures/address/test_invalid_validate
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -55,7 +55,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/1ef351fd0c784e32a45377b0fa172e27/validate
+    uri: https://api.goshippo.com/addresses/1ef351fd0c784e32a45377b0fa172e27/validate
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_list_all
+++ b/shippo/test/fixtures/address/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_list_page_size
+++ b/shippo/test/fixtures/address/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/?results=1
+    uri: https://api.goshippo.com/addresses/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_retrieve
+++ b/shippo/test/fixtures/address/test_retrieve
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -54,7 +54,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/b559f4dea87e4356850908598d06343d
+    uri: https://api.goshippo.com/addresses/b559f4dea87e4356850908598d06343d
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/address/test_validate
+++ b/shippo/test/fixtures/address/test_validate
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -54,7 +54,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/addresses/e150f323a6d6445292f77a56aa082b8f/validate
+    uri: https://api.goshippo.com/addresses/e150f323a6d6445292f77a56aa082b8f/validate
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_add
+++ b/shippo/test/fixtures/batch/test_add
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -68,7 +68,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/80f5a4da3c8d4d5f848d07d0d81f21f7
+    uri: https://api.goshippo.com/batches/80f5a4da3c8d4d5f848d07d0d81f21f7
   response:
     body:
       string: !!binary |
@@ -111,7 +111,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -152,7 +152,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -191,7 +191,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -231,7 +231,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -321,7 +321,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -362,7 +362,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -401,7 +401,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -441,7 +441,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -531,7 +531,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -572,7 +572,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -611,7 +611,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -651,7 +651,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -741,7 +741,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -782,7 +782,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -821,7 +821,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -861,7 +861,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -950,7 +950,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/80f5a4da3c8d4d5f848d07d0d81f21f7/add_shipments
+    uri: https://api.goshippo.com/batches/80f5a4da3c8d4d5f848d07d0d81f21f7/add_shipments
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_create
+++ b/shippo/test/fixtures/batch/test_create
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_invalid_add
+++ b/shippo/test/fixtures/batch/test_invalid_add
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -72,7 +72,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -113,7 +113,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -152,7 +152,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -192,7 +192,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -615,7 +615,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/INVALID_OBJECT_KEY/add_shipments
+    uri: https://api.goshippo.com/batches/INVALID_OBJECT_KEY/add_shipments
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_invalid_create
+++ b/shippo/test/fixtures/batch/test_invalid_create
@@ -15,7 +15,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -53,7 +53,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body: {string: !!python/unicode '{"default_carrier_account": ["Invalid account
         object_id provided ''NOT_VALID''. Please list the available CarrierAccount

--- a/shippo/test/fixtures/batch/test_invalid_purchase
+++ b/shippo/test/fixtures/batch/test_invalid_purchase
@@ -15,7 +15,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/INVALID_OBJECT_ID/purchase
+    uri: https://api.goshippo.com/batches/INVALID_OBJECT_ID/purchase
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_invalid_remove
+++ b/shippo/test/fixtures/batch/test_invalid_remove
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -68,7 +68,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/1bd224c065464ec2acb0cf8881655e53
+    uri: https://api.goshippo.com/batches/1bd224c065464ec2acb0cf8881655e53
   response:
     body:
       string: !!binary |
@@ -106,7 +106,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/INVALID_OBJECT_KEY/add_shipments
+    uri: https://api.goshippo.com/batches/INVALID_OBJECT_KEY/add_shipments
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_invalid_retrieve
+++ b/shippo/test/fixtures/batch/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/batches/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_purchase
+++ b/shippo/test/fixtures/batch/test_purchase
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -68,7 +68,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/ada77cbccc8c4848b98f45b54c31d0d2
+    uri: https://api.goshippo.com/batches/ada77cbccc8c4848b98f45b54c31d0d2
   response:
     body:
       string: !!binary |
@@ -105,7 +105,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/ada77cbccc8c4848b98f45b54c31d0d2
+    uri: https://api.goshippo.com/batches/ada77cbccc8c4848b98f45b54c31d0d2
   response:
     body:
       string: !!binary |
@@ -142,7 +142,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/ada77cbccc8c4848b98f45b54c31d0d2
+    uri: https://api.goshippo.com/batches/ada77cbccc8c4848b98f45b54c31d0d2
   response:
     body:
       string: !!binary |
@@ -179,7 +179,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/ada77cbccc8c4848b98f45b54c31d0d2
+    uri: https://api.goshippo.com/batches/ada77cbccc8c4848b98f45b54c31d0d2
   response:
     body:
       string: !!binary |
@@ -219,7 +219,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/ada77cbccc8c4848b98f45b54c31d0d2/purchase
+    uri: https://api.goshippo.com/batches/ada77cbccc8c4848b98f45b54c31d0d2/purchase
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_remove
+++ b/shippo/test/fixtures/batch/test_remove
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -68,7 +68,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/65fa934d7ce24403bb6ae31213f20d6e
+    uri: https://api.goshippo.com/batches/65fa934d7ce24403bb6ae31213f20d6e
   response:
     body:
       string: !!binary |
@@ -111,7 +111,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -152,7 +152,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -191,7 +191,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -231,7 +231,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -321,7 +321,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -362,7 +362,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -401,7 +401,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -441,7 +441,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -531,7 +531,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -572,7 +572,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -611,7 +611,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -651,7 +651,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -741,7 +741,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -782,7 +782,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -821,7 +821,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -861,7 +861,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -950,7 +950,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/65fa934d7ce24403bb6ae31213f20d6e/add_shipments
+    uri: https://api.goshippo.com/batches/65fa934d7ce24403bb6ae31213f20d6e/add_shipments
   response:
     body:
       string: !!binary |
@@ -995,7 +995,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/65fa934d7ce24403bb6ae31213f20d6e/remove_shipments
+    uri: https://api.goshippo.com/batches/65fa934d7ce24403bb6ae31213f20d6e/remove_shipments
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/batch/test_retrieve
+++ b/shippo/test/fixtures/batch/test_retrieve
@@ -31,7 +31,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/batches/
+    uri: https://api.goshippo.com/batches/
   response:
     body:
       string: !!binary |
@@ -68,7 +68,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/dcfbdcc46a6748b8bd66885ab0ef936c
+    uri: https://api.goshippo.com/batches/dcfbdcc46a6748b8bd66885ab0ef936c
   response:
     body:
       string: !!binary |
@@ -105,7 +105,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/batches/dcfbdcc46a6748b8bd66885ab0ef936c?object_results=creation_succeeded
+    uri: https://api.goshippo.com/batches/dcfbdcc46a6748b8bd66885ab0ef936c?object_results=creation_succeeded
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-declaration/test_create
+++ b/shippo/test/fixtures/customs-declaration/test_create
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |
@@ -59,7 +59,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/declarations/
+    uri: https://api.goshippo.com/customs/declarations/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-declaration/test_invalid_create
+++ b/shippo/test/fixtures/customs-declaration/test_invalid_create
@@ -19,7 +19,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/declarations/
+    uri: https://api.goshippo.com/customs/declarations/
   response:
     body: {string: !!python/unicode '{"items": ["This field is required."]}'}
     headers:

--- a/shippo/test/fixtures/customs-declaration/test_invalid_retrieve
+++ b/shippo/test/fixtures/customs-declaration/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/declarations/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/customs/declarations/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-declaration/test_list_all
+++ b/shippo/test/fixtures/customs-declaration/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/declarations/
+    uri: https://api.goshippo.com/customs/declarations/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-declaration/test_list_page_size
+++ b/shippo/test/fixtures/customs-declaration/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/declarations/?results=1
+    uri: https://api.goshippo.com/customs/declarations/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-declaration/test_retrieve
+++ b/shippo/test/fixtures/customs-declaration/test_retrieve
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |
@@ -59,7 +59,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/declarations/
+    uri: https://api.goshippo.com/customs/declarations/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/declarations/abe769fa8fd949fcb2aac1bf4403d39b
+    uri: https://api.goshippo.com/customs/declarations/abe769fa8fd949fcb2aac1bf4403d39b
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_create
+++ b/shippo/test/fixtures/customs-item/test_create
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_invalid_create
+++ b/shippo/test/fixtures/customs-item/test_invalid_create
@@ -16,7 +16,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_invalid_retrieve
+++ b/shippo/test/fixtures/customs-item/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/items/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/customs/items/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_list_all
+++ b/shippo/test/fixtures/customs-item/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_list_page_size
+++ b/shippo/test/fixtures/customs-item/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/items/?results=1
+    uri: https://api.goshippo.com/customs/items/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/customs-item/test_retrieve
+++ b/shippo/test/fixtures/customs-item/test_retrieve
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/customs/items/
+    uri: https://api.goshippo.com/customs/items/
   response:
     body:
       string: !!binary |
@@ -53,7 +53,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/customs/items/a921d08ac4114b00b46d9d269bcb12b8
+    uri: https://api.goshippo.com/customs/items/a921d08ac4114b00b46d9d269bcb12b8
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/manifest/test_create
+++ b/shippo/test/fixtures/manifest/test_create
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -59,7 +59,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -98,7 +98,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -226,7 +226,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |
@@ -267,7 +267,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/rates/70d211b6359a493ea8745466e989dcf7
+    uri: https://api.goshippo.com/rates/70d211b6359a493ea8745466e989dcf7
   response:
     body:
       string: !!binary |
@@ -306,7 +306,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/79f6872259384d1f9c2a1edfda69e4cd
+    uri: https://api.goshippo.com/shipments/79f6872259384d1f9c2a1edfda69e4cd
   response:
     body:
       string: !!binary |
@@ -398,7 +398,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/manifests/
+    uri: https://api.goshippo.com/manifests/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/manifest/test_invalid_create
+++ b/shippo/test/fixtures/manifest/test_invalid_create
@@ -16,7 +16,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/manifests/
+    uri: https://api.goshippo.com/manifests/
   response:
     body: {string: !!python/unicode '{"address_from": ["Address with supplied object_id
         not found."]}'}

--- a/shippo/test/fixtures/manifest/test_invalid_retrieve
+++ b/shippo/test/fixtures/manifest/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/manifests/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/manifests/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/manifest/test_list_all
+++ b/shippo/test/fixtures/manifest/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/manifests/
+    uri: https://api.goshippo.com/manifests/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/manifest/test_list_page_size
+++ b/shippo/test/fixtures/manifest/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/manifests/?results=1
+    uri: https://api.goshippo.com/manifests/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/manifest/test_retrieve
+++ b/shippo/test/fixtures/manifest/test_retrieve
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -59,7 +59,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -98,7 +98,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -226,7 +226,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |
@@ -267,7 +267,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/rates/07c2382f80314b3eb6d155b50a399e90
+    uri: https://api.goshippo.com/rates/07c2382f80314b3eb6d155b50a399e90
   response:
     body:
       string: !!binary |
@@ -306,7 +306,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/1ea1b4b3132c4579bdffad6de8b1ca16
+    uri: https://api.goshippo.com/shipments/1ea1b4b3132c4579bdffad6de8b1ca16
   response:
     body:
       string: !!binary |
@@ -398,7 +398,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/manifests/
+    uri: https://api.goshippo.com/manifests/
   response:
     body:
       string: !!binary |
@@ -436,7 +436,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/manifests/a4993d2a157f4c3faf8973b5a8912ec1
+    uri: https://api.goshippo.com/manifests/a4993d2a157f4c3faf8973b5a8912ec1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/parcel/test_create
+++ b/shippo/test/fixtures/parcel/test_create
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/parcel/test_invalid_create
+++ b/shippo/test/fixtures/parcel/test_invalid_create
@@ -16,7 +16,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body: {string: !!python/unicode '{"mass_unit": ["This field is required."]}'}
     headers:

--- a/shippo/test/fixtures/parcel/test_invalid_retrieve
+++ b/shippo/test/fixtures/parcel/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/parcels/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/parcels/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/parcel/test_list_all
+++ b/shippo/test/fixtures/parcel/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/parcel/test_list_page_size
+++ b/shippo/test/fixtures/parcel/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/parcels/?results=2
+    uri: https://api.goshippo.com/parcels/?results=2
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/parcel/test_retrieve
+++ b/shippo/test/fixtures/parcel/test_retrieve
@@ -17,7 +17,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -52,7 +52,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/parcels/8221d42fbe1540a0bff22d05f27d2f8d
+    uri: https://api.goshippo.com/parcels/8221d42fbe1540a0bff22d05f27d2f8d
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/pickup/test_create
+++ b/shippo/test/fixtures/pickup/test_create
@@ -26,7 +26,7 @@ interactions:
         21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
         x86_64 i386"}'
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -93,7 +93,7 @@ interactions:
         21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
         x86_64 i386"}'
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -158,7 +158,7 @@ interactions:
         21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
         x86_64 i386"}'
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -224,7 +224,7 @@ interactions:
         21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
         x86_64 i386"}'
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -307,7 +307,7 @@ interactions:
         21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
         x86_64 i386"}'
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/rate/test_invalid_retrieve
+++ b/shippo/test/fixtures/rate/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/rates/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/rates/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/rate/test_retrieve
+++ b/shippo/test/fixtures/rate/test_retrieve
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -214,7 +214,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/6da788bc6ba14977bd76a176f80b9d96
+    uri: https://api.goshippo.com/shipments/6da788bc6ba14977bd76a176f80b9d96
   response:
     body:
       string: !!binary |
@@ -291,7 +291,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/6da788bc6ba14977bd76a176f80b9d96/rates/
+    uri: https://api.goshippo.com/shipments/6da788bc6ba14977bd76a176f80b9d96/rates/
   response:
     body:
       string: !!binary |
@@ -354,7 +354,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/rates/649bbd5c82ea44a7b8027cd234688d90
+    uri: https://api.goshippo.com/rates/649bbd5c82ea44a7b8027cd234688d90
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_create
+++ b/shippo/test/fixtures/shipment/test_create
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_get_rate
+++ b/shippo/test/fixtures/shipment/test_get_rate
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -214,7 +214,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/65f3d47fb7b24d678a7c61b0b7452c61
+    uri: https://api.goshippo.com/shipments/65f3d47fb7b24d678a7c61b0b7452c61
   response:
     body:
       string: !!binary |
@@ -291,7 +291,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/65f3d47fb7b24d678a7c61b0b7452c61/rates/
+    uri: https://api.goshippo.com/shipments/65f3d47fb7b24d678a7c61b0b7452c61/rates/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_get_rates_blocking
+++ b/shippo/test/fixtures/shipment/test_get_rates_blocking
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -214,7 +214,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/93808674a27a4f7f808d1742a4dfc273
+    uri: https://api.goshippo.com/shipments/93808674a27a4f7f808d1742a4dfc273
   response:
     body:
       string: !!binary |
@@ -291,7 +291,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/93808674a27a4f7f808d1742a4dfc273/rates/
+    uri: https://api.goshippo.com/shipments/93808674a27a4f7f808d1742a4dfc273/rates/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_invalid_create
+++ b/shippo/test/fixtures/shipment/test_invalid_create
@@ -19,7 +19,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body: {string: !!python/unicode '{"customs_declaration": ["CustomsDeclaration
         with supplied object_id b741b99f95e841639b54272834bc478c not found."], "parcels":

--- a/shippo/test/fixtures/shipment/test_invalid_get_rate
+++ b/shippo/test/fixtures/shipment/test_invalid_get_rate
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/EXAMPLE_OF_INVALID_ID/rates/
+    uri: https://api.goshippo.com/shipments/EXAMPLE_OF_INVALID_ID/rates/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_invalid_retrieve
+++ b/shippo/test/fixtures/shipment/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/shipments/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_list_all
+++ b/shippo/test/fixtures/shipment/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_list_page_size
+++ b/shippo/test/fixtures/shipment/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/?results=1
+    uri: https://api.goshippo.com/shipments/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/shipment/test_retrieve
+++ b/shippo/test/fixtures/shipment/test_retrieve
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -214,7 +214,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/507cbe31a5f043baaa597a6c021e166a
+    uri: https://api.goshippo.com/shipments/507cbe31a5f043baaa597a6c021e166a
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/track/test_create
+++ b/shippo/test/fixtures/track/test_create
@@ -16,7 +16,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/tracks/
+    uri: https://api.goshippo.com/tracks/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/track/test_get_status
+++ b/shippo/test/fixtures/track/test_get_status
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/tracks/usps/9205590164917337534322
+    uri: https://api.goshippo.com/tracks/usps/9205590164917337534322
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/track/test_invalid_create
+++ b/shippo/test/fixtures/track/test_invalid_create
@@ -16,7 +16,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/tracks/
+    uri: https://api.goshippo.com/tracks/
   response:
     body: {string: !!python/unicode '{"carrier": ["Invalid value specified for provider
         ''EXAMPLE_OF_INVALID_CARRIER''"]}'}
@@ -47,7 +47,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/tracks/
+    uri: https://api.goshippo.com/tracks/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/track/test_invalid_get_status
+++ b/shippo/test/fixtures/track/test_invalid_get_status
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/tracks/EXAMPLE_OF_INVALID_CARRIER/9205590164917337534322
+    uri: https://api.goshippo.com/tracks/EXAMPLE_OF_INVALID_CARRIER/9205590164917337534322
   response:
     body: {string: !!python/unicode '{"detail": "Carrier with name ''EXAMPLE_OF_INVALID_CARRIER''
         is not supported."}'}
@@ -43,7 +43,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/tracks/usps/EXAMPLE_OF_INVALID_TRACKING_NUMBER
+    uri: https://api.goshippo.com/tracks/usps/EXAMPLE_OF_INVALID_TRACKING_NUMBER
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/transaction/test_create
+++ b/shippo/test/fixtures/transaction/test_create
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -215,7 +215,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/f114687f56084b969b7392192f5c3198
+    uri: https://api.goshippo.com/shipments/f114687f56084b969b7392192f5c3198
   response:
     body:
       string: !!binary |
@@ -292,7 +292,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/f114687f56084b969b7392192f5c3198/rates/
+    uri: https://api.goshippo.com/shipments/f114687f56084b969b7392192f5c3198/rates/
   response:
     body:
       string: !!binary |
@@ -356,7 +356,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/transaction/test_invalid_create
+++ b/shippo/test/fixtures/transaction/test_invalid_create
@@ -15,7 +15,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body: {string: !!python/unicode '{"rate": ["This field is required."]}'}
     headers:

--- a/shippo/test/fixtures/transaction/test_invalid_retrieve
+++ b/shippo/test/fixtures/transaction/test_invalid_retrieve
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/transactions/EXAMPLE_OF_INVALID_ID
+    uri: https://api.goshippo.com/transactions/EXAMPLE_OF_INVALID_ID
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/transaction/test_list_all
+++ b/shippo/test/fixtures/transaction/test_list_all
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/transaction/test_list_page_size
+++ b/shippo/test/fixtures/transaction/test_list_page_size
@@ -14,7 +14,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/transactions/?results=1
+    uri: https://api.goshippo.com/transactions/?results=1
   response:
     body:
       string: !!binary |

--- a/shippo/test/fixtures/transaction/test_retrieve
+++ b/shippo/test/fixtures/transaction/test_retrieve
@@ -18,7 +18,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -58,7 +58,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/addresses/
+    uri: https://api.goshippo.com/addresses/
   response:
     body:
       string: !!binary |
@@ -97,7 +97,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/parcels/
+    uri: https://api.goshippo.com/parcels/
   response:
     body:
       string: !!binary |
@@ -138,7 +138,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/shipments/
+    uri: https://api.goshippo.com/shipments/
   response:
     body:
       string: !!binary |
@@ -215,7 +215,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/3edd1b7b674e4b0cacfa4291ab1841cf
+    uri: https://api.goshippo.com/shipments/3edd1b7b674e4b0cacfa4291ab1841cf
   response:
     body:
       string: !!binary |
@@ -292,7 +292,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/shipments/3edd1b7b674e4b0cacfa4291ab1841cf/rates/
+    uri: https://api.goshippo.com/shipments/3edd1b7b674e4b0cacfa4291ab1841cf/rates/
   response:
     body:
       string: !!binary |
@@ -357,7 +357,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: POST
-    uri: https://api.goshippo.com/v1/transactions/
+    uri: https://api.goshippo.com/transactions/
   response:
     body:
       string: !!binary |
@@ -393,7 +393,7 @@ interactions:
           x86_64 i386", "lang_version": "2.7.10", "platform": "Darwin-16.4.0-x86_64-i386-64bit",
           "bindings_version": "1.4.0"}']
     method: GET
-    uri: https://api.goshippo.com/v1/transactions/9fe77395e75e41fa86ec08fdc2a28d8c
+    uri: https://api.goshippo.com/transactions/9fe77395e75e41fa86ec08fdc2a28d8c
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
After exporting `SHIPPO_API_KEY` and removing v1 from urls in tests everything passed

<img width="522" alt="image" src="https://user-images.githubusercontent.com/61479880/172891819-e689ccb0-5315-43f1-91f6-3a7a9f269c37.png">
