### PR TITLE
setup.py: Drop specific Requests version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['shippo', 'shippo.test', 'shippo.test.integration'],
     package_data={'shippo': ['../VERSION']},
     install_requires=[
-        'requests >= 2.21.0, <= 2.27.1',
+        'requests',
         'simplejson >= 3.16.0, <= 3.17.2',
     ],
     test_suite='shippo.test.all',


### PR DESCRIPTION
Shippo currently broken due to new release, just like it was for last release, and there appears to be no documentation on why this was necessary. This would unbreak us and, doubtlessly, others.