### PR TITLE
Test setup without mocked VCR responses from Shippo API

### DIFF
--- a/shippo/config.py
+++ b/shippo/config.py
@@ -20,7 +20,14 @@ class Configuration:
         self.verify_ssl_certs = True
         self.timeout_in_seconds: Optional[float] = None
         self.rates_req_timeout = float(os.environ.get('RATES_REQ_TIMEOUT', 20.0))
+
+        # SETTINGS BELOW APPLY ONLY TO TESTS
+
+        # Controls how much information is logged to stdout
         self.vcr_logging_level = os.environ.get('VCR_LOGGING_LEVEL', 'ERROR')
+
+        # Switch to 'all' for re-recording all cassettes (to be used in CI so that all tests are run without mocks)
+        self.vcr_record_mode = os.environ.get('VCR_RECORD_MODE', 'once')
 
 
 config = Configuration()

--- a/shippo/test/helper.py
+++ b/shippo/test/helper.py
@@ -498,5 +498,6 @@ class ShippoApiTestCase(ShippoTestCase):
 
 
 shippo_vcr = vcr.VCR(
-    filter_headers=['Authorization']
+    filter_headers=['Authorization'],
+    record_mode=config.vcr_record_mode
 )

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,4 @@ setenv =
     VCR_RECORD_MODE=all
 
 commands =
-    pytest -v shippo/test/integration/test_integration.py::FunctionalTests
+    pytest -v shippo/test

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,15 @@ deps =
 
 commands =
     pytest -v
+
+
+# This test setup will run all tests without using the previously recorded VCR cassettes
+# (in GitHub Actions all cassettes will be re-recorded and discarded after the test suite finishes)
+[testenv:live]
+setenv =
+    SHIPPO_API_KEY={env:SHIPPO_API_KEY}
+    SHIPPO_API_BASE={env:SHIPPO_API_BASE}
+    VCR_RECORD_MODE=all
+
+commands =
+    pytest -v shippo/test/integration/test_integration.py::FunctionalTests


### PR DESCRIPTION
- Make VCR cassettes recording configurable via an env var
- When passing `all` as `VCR_RECORD_MODE` all VCR cassettes will be re-recorded
- Create another `tox` test environment for running all tests without using the mocked VCR responses