### PR TITLE
Add chardet dependency for the requests library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         # Primary container image where all commands run
 
         docker:
-            - image: circleci/python:3.5.7  # primary container for the build job
+            - image: circleci/python:3.6.5  # primary container for the build job
               auth:
                   username: mydockerhub-user
                   password: $DOCKERHUB_PASSWORD

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import warnings
 from setuptools import setup
 
 
@@ -20,6 +18,7 @@ setup(
     packages=['shippo', 'shippo.test', 'shippo.test.integration'],
     package_data={'shippo': ['../VERSION']},
     install_requires=[
+        'chardet',
         'requests',
         'simplejson >= 3.16.0, <= 3.17.2',
     ],
@@ -34,6 +33,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,6 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
-
-[tox]
-envlist = python3.5, python3.6, python3.7
-
 [testenv]
 setenv =
     SHIPPO_API_KEY={env:SHIPPO_API_KEY}


### PR DESCRIPTION
- Add `chardet` dependency for the `requests` library
- remove `[tox] -> envlist` from `tox.init`, because the tests are run on the current python version anyway (CircleCI Python docker image with a specific version or GitHub Action Workflow also with a specific version)
- drops support for Python 3.5 (this Python version has been discontinued and is causing constant issues with packages not being able to resolve their dependencies)