### PR TITLE
chore: downgrade ubuntu version to allow py 3.6 to continue running

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ENG-32581 - Fix failing shippo-python-client sdk test

Github actions no longer support python 3.6 on ubuntu-latest-- https://github.com/actions/setup-python/issues/544#issuecomment-1332535877

Downgrading ubuntu to continue supporting 3.6.